### PR TITLE
feat: add nightly support for nearcore additional binaries 

### DIFF
--- a/frontend/src/a_test.js
+++ b/frontend/src/a_test.js
@@ -14,9 +14,13 @@ export function parseTestName(test) {
     const spec = test.name.trim().split(/\s+/);
     const category = spec[0];
     const pos = spec.indexOf('--features');
-    const features = pos !== -1
-          ? ' ' + spec.splice(pos).join(' ') + ',test_features'
+    const featuresArray = pos !== -1 ? spec.splice(pos) : [];
+    const features = featuresArray.length > 0
+          ? ' ' + featuresArray.join(' ') + ',test_features'
           : ' --features test_features';
+    const additionalBinariesFeatures = featuresArray.includes("nightly")
+        ? '--features nightly '
+        : ' ';
     let release = '';
     let i = 1;
     for (; /^--/.test(spec[i] || ''); ++i) {
@@ -43,7 +47,7 @@ export function parseTestName(test) {
         command = 'python3 pytest/tests/' + spec.join(' ');
         command = test.skip_build ? <code>{command}</code> : <code>
           <small>cargo build {release} -pneard {features},rosetta_rpc &amp;&amp;</small><br/>
-          <small>cargo build {release} -pgenesis-populate -prestaked -pnear-test-contracts &amp;&amp;</small><br/>
+          <small>cargo build {release} -pgenesis-populate -prestaked -pnear-test-contracts {additionalBinariesFeatures}&amp;&amp;</small><br/>
           {command}
         </code>;
         break;

--- a/frontend/src/a_test.js
+++ b/frontend/src/a_test.js
@@ -16,7 +16,7 @@ export function parseTestName(test) {
     const pos = spec.indexOf('--features');
     const featuresArray = pos !== -1 ? spec.splice(pos) : [];
     const features = featuresArray.length > 0
-          ? ' ' + featuresArray.join(',') + ',test_features'
+          ? ' ' + featuresArray.join(' ') + ',test_features'
           : ' --features test_features';
     const additionalBinariesFeatures = featuresArray.includes('nightly')
         ? '--features nightly '

--- a/frontend/src/a_test.js
+++ b/frontend/src/a_test.js
@@ -16,7 +16,7 @@ export function parseTestName(test) {
     const pos = spec.indexOf('--features');
     const featuresArray = pos !== -1 ? spec.splice(pos) : [];
     const features = featuresArray.length > 0
-          ? ' ' + featuresArray.join(' ') + ',test_features'
+          ? ' ' + featuresArray.join(',') + ',test_features'
           : ' --features test_features';
     const additionalBinariesFeatures = featuresArray.includes('nightly')
         ? '--features nightly '

--- a/frontend/src/a_test.js
+++ b/frontend/src/a_test.js
@@ -18,7 +18,7 @@ export function parseTestName(test) {
     const features = featuresArray.length > 0
           ? ' ' + featuresArray.join(' ') + ',test_features'
           : ' --features test_features';
-    const additionalBinariesFeatures = featuresArray.includes("nightly")
+    const additionalBinariesFeatures = featuresArray.includes('nightly')
         ? '--features nightly '
         : ' ';
     let release = '';

--- a/frontend/src/a_test.js
+++ b/frontend/src/a_test.js
@@ -20,7 +20,7 @@ export function parseTestName(test) {
           : ' --features test_features';
     const additionalBinariesFeatures = featuresArray.includes('nightly')
         ? '--features nightly '
-        : ' ';
+        : '';
     let release = '';
     let i = 1;
     for (; /^--/.test(spec[i] || ''); ++i) {

--- a/workers/builder.py
+++ b/workers/builder.py
@@ -108,7 +108,7 @@ def build_target(spec: BuildSpec, runner: utils.Runner) -> None:
         '-prestaked',
         '-pnear-test-contracts'
     ]
-    if spec.features and "nightly" in spec.features.split(","):
+    if spec.features and ("nightly" in spec.features.split(",")):
         build_additional_binaries_args.append("--features=nightly")
     cargo(*build_additional_binaries_args, add_features=False)
 

--- a/workers/builder.py
+++ b/workers/builder.py
@@ -101,11 +101,16 @@ def build_target(spec: BuildSpec, runner: utils.Runner) -> None:
 
     cargo('build', '-pneard', '--bin', 'neard', '--features',
           f'{test_feature},rosetta_rpc')
-    cargo('build',
-          '-pgenesis-populate',
-          '-prestaked',
-          '-pnear-test-contracts',
-          add_features=False)
+
+    build_additional_binaries_args = [
+        'build',
+        '-pgenesis-populate',
+        '-prestaked',
+        '-pnear-test-contracts'
+    ]
+    if spec.features and "nightly" in spec.features.split(","):
+        build_additional_binaries_args.append("--features=nightly")
+    cargo(*build_additional_binaries_args, add_features=False)
 
     copy(src_dir=utils.REPO_DIR / 'target' / spec.build_type,
          dst_dir=spec.build_dir / 'target',


### PR DESCRIPTION
Currently we do not build `genesis-populate` binary with nightly features when `--features nightly` is passed to `pytest`.
For example see [this test run](https://nayduck.near.org/#/test/416389):
```
Test	               pytest --timeout=1h sanity/state_sync_massive.py --features nightly

           	       cargo build -pneard --features nightly,test_features,rosetta_rpc &&
Command                cargo build -pgenesis-populate -prestaked -pnear-test-contracts &&
                       python3 pytest/tests/sanity/state_sync_massive.py
```

This is problematic since some tests require nightly features to be enabled for `genesis-populate` as well. For example https://github.com/near/nearcore/pull/8417 enables flat state for `genesis-populate` which is currently enabled via nightly features.

This PR propagates `--features=nightly` to `cargo build` for `genesis-populate` and other additional nearcore binaries.