### PR TITLE
fix: removing sql alchemy encoding

### DIFF
--- a/lib/common_db.py
+++ b/lib/common_db.py
@@ -24,8 +24,7 @@ def __create_engine() -> sqlalchemy.engine.Engine:
                                     future=True,
                                     pool_size=1,
                                     pool_recycle=4 * 3600,
-                                    max_overflow=20,
-                                    encoding='utf-8')
+                                    max_overflow=20)
 
 
 _ENGINE = __create_engine()


### PR DESCRIPTION
Removing encoding constructs to adjust per latest sqlalchemy 2.0.1 changes:
```
All Unicode encoding/decoding architecture has been removed from SQLAlchemy. All modern DBAPI implementations support Unicode transparently thanks to Python 3, so the convert_unicode feature as well as related mechanisms to look for bytestrings in DBAPI cursor.description etc. have been removed.
```

without this, upon upgrading sqlalchemy, builders and workers will fail with:
```
Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/nayduck/nayduck/workers/builder.py", line 12, in <module>
    from . import builder_db
  File "/home/nayduck/nayduck/workers/builder_db.py", line 3, in <module>
    from lib import common_db
  File "/home/nayduck/nayduck/lib/common_db.py", line 31, in <module>
    _ENGINE = __create_engine()
  File "/home/nayduck/nayduck/lib/common_db.py", line 23, in __create_engine
    return sqlalchemy.create_engine(url,
  File "<string>", line 2, in create_engine
  File "/home/nayduck/.local/lib/python3.9/site-packages/sqlalchemy/util/deprecations.py", line 277, in warned
    return fn(*args, **kwargs)  # type: ignore[no-any-return]
  File "/home/nayduck/.local/lib/python3.9/site-packages/sqlalchemy/engine/create.py", line 693, in create_engine
    raise TypeError(
TypeError: Invalid argument(s) 'encoding' sent to create_engine(), using configuration PGDialect_psycopg2/QueuePool/Engine.  Please check that the keyword arguments are appropriate for this combination of components.
```