### PR TITLE
fix: add missing cargo argument

### DIFF
--- a/workers/builder.py
+++ b/workers/builder.py
@@ -145,7 +145,7 @@ def build_target(spec: BuildSpec, runner: utils.Runner) -> None:
         '--tests',
         '--target-dir',
         'target_expensive',
-        features='expensive_tests'
+        features=['expensive_tests']
     )
 
     copy(src_dir=src_dir,

--- a/workers/builder.py
+++ b/workers/builder.py
@@ -140,8 +140,13 @@ def build_target(spec: BuildSpec, runner: utils.Runner) -> None:
             if '.' not in filename:
                 (src_dir / filename).unlink()
 
-    cargo('build', '--tests', '--target-dir', 'target_expensive',
-          '--features=expensive_tests')
+    cargo(
+        'build',
+        '--tests',
+        '--target-dir',
+        'target_expensive',
+        features='expensive_tests'
+    )
 
     copy(src_dir=src_dir,
          dst_dir=spec.build_dir / 'expensive',


### PR DESCRIPTION
Refactor introduced in https://github.com/near/nayduck/pull/38 results in broken builds: https://nayduck.near.org/#/build/4196

```
Traceback (most recent call last):
  File "/home/nayduck/nayduck/workers/builder.py", line 202, in handle_build
    build_target(spec, runner=runner)
  File "/home/nayduck/nayduck/workers/builder.py", line 143, in build_target
    cargo('build', '--tests', '--target-dir', 'target_expensive',
TypeError: cargo() missing 1 required keyword-only argument: 'features'
```