### PR TITLE
Fix underscores in tests artifacts parsing

### DIFF
--- a/workers/worker.py
+++ b/workers/worker.py
@@ -258,7 +258,8 @@ def list_logs(directory: pathlib.Path,
         if entry_path.is_dir():
             path = entry_path / 'stderr'
             if path.exists():
-                yield LogFile(entry.split('_')[0], path)
+                # Exclude the _finished part (set at cleanup phase bit.ly/3UbqdMR)
+                yield LogFile(entry.split('_finished')[0], path)
         elif entry in ('stderr', 'stdout'):
             yield LogFile(entry, entry_path)
 


### PR DESCRIPTION
multiple underscores in test artifacts can lead to messed log paths and failed db inserts:

```
Apr 06 09:01:12 worker4 python3[3890804]: [RUNNING] pytest --timeout=3m sanity/split_storage.py
Apr 06 09:01:12 worker4 python3[3890804]: + cd /datadrive/nearcore/pytest
Apr 06 09:01:12 worker4 python3[3890804]: + /usr/bin/python3 tests/sanity/split_storage.py
Apr 06 09:03:41 worker4 python3[3890804]: [FAILED ] pytest --timeout=3m sanity/split_storage.py
Apr 06 09:03:41 worker4 python3[3890804]: + tar -cvhI xz -9 --exclude-backups --exclude=stderr --null -T-

Apr 06 09:03:43 worker4 python3[3890804]: sqlalchemy.exc.ProgrammingError: (psycopg2.errors.CardinalityViolation) ON CONFLICT DO UPDATE command cannot affect row a second time
Apr 06 09:03:43 worker4 python3[3890804]: HINT:  Ensure that no rows proposed for insertion within the same command have duplicate constrained values.

[SQL: INSERT INTO "logs" ("test_id", "type", "size", "log", "storage", "stack_trace") VALUES 
 (%(r0c0)s, %(r0c1)s, %(r0c2)s, %(r0c3)s, %(r0c4)s, %(r0c5)s), 
 (%(r1c0)s, %(r1c1)s, %(r1c2)s, %(r1c3)s, %(r1c4)s, %(r1c5)s), 
 (%(r2c0)s, %(r2c1)s, %(r2c2)s, %(r2c3)s, %(r2c4)s, %(r2c5)s), 
 (%(r3c0)s, %(r3c1)s, %(r3c2)s, %(r3c3)s, %(r3c4)s, %(r3c5)s), 
 (%(r4c0)s, %(r4c1)s, %(r4c2)s, %(r4c3)s, %(r4c4)s, %(r4c5)s), 
 (%(r5c0)s, %(r5c1)s, %(r5c2)s, %(r5c3)s, %(r5c4)s, %(r5c5)s) 
 ON CONFLICT (test_id, type) DO UPDATE SET size = excluded.size, log = excluded.log,     storage = excluded.storage,     stack_trace = excluded.stack_trace]

[parameters: {
'r0c0': 444924, 'r0c1': 'test', 'r0c2': 361922, 'r0c3': <psycopg2.extensions.Binary object at 0x7fde003d0660>, 'r0c4': 'link_here/test_444924_test', 'r0c5': False,
'r1c0': 444924, 'r1c1': 'test', 'r1c2': 355142, 'r1c3': <psycopg2.extensions.Binary object at 0x7fde003d0450>, 'r1c4': 'link_here/test_444924_test', 'r1c5': False, 
'r2c0': 444924, 'r2c1': 'test', 'r2c2': 403642, 'r2c3': <psycopg2.extensions.Binary object at 0x7fde003d0b40>, 'r2c4': 'link_here/test_444924_test', 'r2c5': False, 
'r3c0': 444924, 'r3c1': 'stderr', 'r3c2': 553, 'r3c3': <psycopg2.extensions.Binary object at 0x7fde003d0870>, 'r3c4': '/logs/test/444924/stderr', 'r3c5': False, 
'r4c0': 444924, 'r4c1': 'test', 'r4c2': 459628, 'r4c3': <psycopg2.extensions.Binary object at 0x7fde003d0ba0>, 'r4c4': 'link_here/test_444924_test', 'r4c5': False, 
'r5c0': 444924, 'r5c1': 'stdout', 'r5c2': 9598, 'r5c3': <psycopg2.extensions.Binary object at 0x7fde003d0120>, 'r5c4': '/logs/test/444924/stdout', 'r5c5': False
}]

Apr 06 09:03:43 worker4 python3[3890804]: (Background on this error at: https://sqlalche.me/e/14/f405)
```
