### PR TITLE
Fix: stale tests handling

### DIFF
--- a/backend/backend_db.py
+++ b/backend/backend_db.py
@@ -443,7 +443,8 @@ class BackendDB(common_db.DB):
 
         def execute() -> int:
             sql = '''UPDATE tests
-                        SET status = 'PENDING'
+                        SET status = 'PENDING',
+                            tries = tries - 1
                       WHERE test_id IN :ids
                         AND status = 'RUNNING'
                       '''


### PR DESCRIPTION
Sometimes tests may fail to get updated in DB and remain in forever RUNNING state.
This change will clear such tests and place them in PENDING state so these can be picked up and ran again.