### PR TITLE
fetch the specific commit to be checked out

### DIFF
--- a/workers/utils.py
+++ b/workers/utils.py
@@ -236,13 +236,14 @@ def checkout(sha: str, runner: Runner) -> bool:
             cwd=REPO_DIR)
         # yapf: disable
         if ((result.returncode == 0 or
-             runner(('git', 'remote', 'update', '-p'), cwd=REPO_DIR) == 0) and
+             runner(('git', 'fetch', 'origin', '-p', sha), cwd=REPO_DIR) == 0) and
             runner(('git', 'checkout', '-f', sha), cwd=REPO_DIR) == 0):
             return True
         # yapf: enable
         rmdirs(REPO_DIR)
 
     return (runner(('git', 'clone', REPO_URL), cwd=REPO_DIR.parent) == 0 and
+            runner(('git', 'fetch', 'origin', '-p', sha), cwd=REPO_DIR) == 0) and
             runner(('git', 'checkout', '-f', sha), cwd=REPO_DIR) == 0)
 
 


### PR DESCRIPTION
by default fetching/updating the repository only really fetches a handful of references. Requested commit might exist at the repository still on a reference that isn't fetched by default (e.g. at refs/pull/$PID/head.)

Do the proper thing and ask the remote to supply the exact ref we want to test.