### PR TITLE
fetch commit when scheduling a job too...

### DIFF
--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -115,6 +115,7 @@ class CommitInfo(typing.NamedTuple):
             Failure: if git command returns an error (most probably because the
                 commit does not exist).
         """
+        _run(*('git', 'fetch', 'origin', '-p', sha), cwd=repo_dir)
         cmd = ('git', 'log', '--format=%H\n%s', '-n1', sha, '--')
         sha, title = _run(*cmd, cwd=repo_dir).decode('utf-8',
                                                      'replace').splitlines()


### PR DESCRIPTION
Otherwise we see failures like

    ++ python3 ./scripts/nayduck.py --test-file nightly/ci.txt
    + NEW_TEST='Scheduling tests for: branch - remotes/pull/14315/head commit hash - b25c7669e82a1b62316430d4df3642ed744bc230 Sending request ... Failure. Command <git log '\''--format=%H %s'\'' -n1 b25c7669e82a1b62316430d4df3642ed744bc230 --> terminated with exit code 128: fatal: bad object b25c7669e82a1b62316430d4df3642ed744bc230 '